### PR TITLE
BinaryCompatChecker: Add /intPtrCtors option

### DIFF
--- a/src/BinaryCompatChecker/BinaryCompatChecker.csproj
+++ b/src/BinaryCompatChecker/BinaryCompatChecker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <LangVersion>preview</LangVersion>
     <RollForward>major</RollForward>

--- a/src/BinaryCompatChecker/BinaryCompatChecker.nuspec
+++ b/src/BinaryCompatChecker/BinaryCompatChecker.nuspec
@@ -13,10 +13,10 @@
     <repository url="https://github.com/KirillOsenkov/MetadataTools" />
   </metadata>
   <files>
-    <file src="bin\Debug\net5.0\BinaryCompatChecker.dll" target="tools\BinaryCompatChecker.dll" />
-    <file src="bin\Debug\net5.0\BinaryCompatChecker.exe" target="tools\BinaryCompatChecker.exe" />
-    <file src="bin\Debug\net5.0\BinaryCompatChecker.runtimeconfig.json" target="tools\BinaryCompatChecker.runtimeconfig.json" />
-    <file src="bin\Debug\net5.0\Mono.Cecil.dll" target="tools\Mono.Cecil.dll" />
+    <file src="bin\Debug\net6.0\BinaryCompatChecker.dll" target="tools\BinaryCompatChecker.dll" />
+    <file src="bin\Debug\net6.0\BinaryCompatChecker.exe" target="tools\BinaryCompatChecker.exe" />
+    <file src="bin\Debug\net6.0\BinaryCompatChecker.runtimeconfig.json" target="tools\BinaryCompatChecker.runtimeconfig.json" />
+    <file src="bin\Debug\net6.0\Mono.Cecil.dll" target="tools\Mono.Cecil.dll" />
     <file src="BinaryCompatChecker.props" target="build\BinaryCompatChecker.props" />
   </files>
 </package>


### PR DESCRIPTION
This allows checking all `ObjCRuntime.INativeObect` implementors to
ensure they are not using `IntPtr` in their constructors, which will
cause runtime crashes with Preview 13 of the .NET 6 macos workload.