### PR TITLE
Support default interface method implementations in BinaryCompatChecker

### DIFF
--- a/src/BinaryCompatChecker/Program.cs
+++ b/src/BinaryCompatChecker/Program.cs
@@ -1112,6 +1112,12 @@ namespace BinaryCompatChecker
                                             continue;
                                         }
 
+                                        if (interfaceMethod.HasBody)
+                                        {
+                                            // Default method implementation provided by the interface itself
+                                            continue;
+                                        }
+
                                         bool sawGenerics = false;
                                         var matching = FindInterfaceMethodImplementation(typeDef, interfaceMethod, ref sawGenerics);
                                         if (matching == null && !sawGenerics)


### PR DESCRIPTION
When checking for binary compatibility there is no need for a type to implement methods that have default implementations provided by the interface. Handle this by checking to see if the interface method has a body and not checking this method is implemented by the type.

Fixes #16

To test this I ran the binary compat checker against System.Private.CoreLib.dll from .NET 7 RC 1.

Before:

```
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Byte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Char does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Collections.Generic.NonRandomizedStringEqualityComparer does not implement interface method System.Collections.Generic.IEqualityComparer`1<System.String> System.Collections.Generic.IInternalStringEqualityComparer::GetUnderlyingEqualityComparer(System.Collections.Generic.IEqualityComparer`1<System.String>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Decimal does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Double does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Half does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Int64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.IntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Runtime.InteropServices.NFloat does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.SByte does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteExponentLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.Single does not implement interface method System.Int32 System.Numerics.IFloatingPoint`1::WriteSignificandLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt128 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt16 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt32 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UInt64 does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteBigEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[],System.Int32) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Byte[]) from assembly System.Private.CoreLib.dll
In assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e': Type System.UIntPtr does not implement interface method System.Int32 System.Numerics.IBinaryInteger`1::WriteLittleEndian(System.Span`1<System.Byte>) from assembly System.Private.CoreLib.dll
```

After:

Report was empty.