### PR TITLE
fix #32 +1 bug

### DIFF
--- a/src/BinaryCompatChecker/Assemblies.cs
+++ b/src/BinaryCompatChecker/Assemblies.cs
@@ -118,13 +118,15 @@ public partial class Checker
             return result;
         }
 
-        result = TryResolveFromInputFiles(reference);
+        // codeBase takes precedence over the input files, see:
+        // https://learn.microsoft.com/en-us/dotnet/framework/deployment/how-the-runtime-locates-assemblies
+        result = TryResolveFromCodeBase(reference);
         if (result != null)
         {
             return result;
         }
 
-        result = TryResolveFromCodeBase(reference);
+        result = TryResolveFromInputFiles(reference);
         if (result != null)
         {
             return result;

--- a/src/BinaryCompatChecker/BindingRedirects.cs
+++ b/src/BinaryCompatChecker/BindingRedirects.cs
@@ -170,7 +170,8 @@ public partial class Checker
             foundNewVersion = true;
         }
 
-        if (!foundNewVersion)
+        // Suppress message if an assemblyBinding node has no bindingRedirects, for example it has codeBase only.
+        if (bindingRedirect.BindingRedirectElement != null && !foundNewVersion)
         {
             string withVersion = "";
             if (newVersion != null)


### PR DESCRIPTION
Fix #32, also fix a bug where a report line is generated falsely if an assemblyBinding element has no bindingRedirects at all. 

Attached is the repo used to test the tool.
[repo.zip](https://github.com/user-attachments/files/19274646/repo.zip)